### PR TITLE
GolangCI v1.42.1; Remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,19 +72,18 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
     - gomnd
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
     - misspell
     - nakedret
     - noctx
     - nolintlint
+    - revive
     - rowserrcheck
     - staticcheck
     - stylecheck
@@ -131,6 +130,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.23.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.42.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ fmt:
 	go fmt ./...
 
 lint:
-	golint `go list ./... | grep -v vendor`
 	golangci-lint run
 
 tests:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ At a minimum, the following dependencies must be installed to work with the GoLa
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.16
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.32.2
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.42.1
 
 ## Modifying the claim schema
 


### PR DESCRIPTION
Changes:
- golint was deprecated [last year](https://github.com/golang/go/issues/38968).
- GolangCI-Lint's latest release is [1.42.1](https://github.com/golangci/golangci-lint/releases/tag/v1.42.1).