### PR TITLE
Go 1.17.3 update

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.2
+          go-version: 1.17.3
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.2
+          go-version: 1.17.3
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2


### PR DESCRIPTION
Go 1.17.3 is now [available](https://twitter.com/golang/status/1456314310330880004).

Includes security fixes to archive/zip and debug/macho (CVE-2021-41772, CVE-2021-41771).