### PR TITLE
Update Go to 1.17.6

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.17.6
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.17.6
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2


### PR DESCRIPTION
Go 1.17.6 is now available.

https://twitter.com/golang/status/1479199301352013829

From their release page:
```
go1.17.6 (released 2022-01-06) includes fixes to the compiler, linker, runtime, and the crypto/x509, net/http, and reflect packages. See the Go 1.17.6 milestone on our issue tracker for details.
```