### PR TITLE
Bump GolangCI-lint to v1.44.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,6 +130,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.43.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.44.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ fmt:
 	go fmt ./...
 
 lint:
-	golangci-lint run
+	golangci-lint run --timeout 5m0s
 
 tests:
 	go test -coverprofile=cover.out ./...

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ At a minimum, the following dependencies must be installed to work with the GoLa
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.17
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.43.0
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.44.1
 
 ## Modifying the claim schema
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.44.1

No code changes found/needed.