### PR TITLE
Update GolangCI to 1.45.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,6 +130,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.44.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.45.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ At a minimum, the following dependencies must be installed to work with the GoLa
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.17
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.44.1
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.45.2
 
 ## Modifying the claim schema
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.45.2

Similar to:
https://github.com/test-network-function/cnf-certification-test/pull/92
https://github.com/test-network-function/test-network-function/pull/660
https://github.com/test-network-function/cnfcert-tests-verification/pull/55