### PR TITLE
Upgrade to Go 1.18.1

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.9
+          go-version: 1.18.1
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.9
+          go-version: 1.18.1
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ At a minimum, the following dependencies must be installed to work with the GoLa
 
 Dependency|Minimum Version
 ---|---
-[GoLang](https://golang.org/dl/)|1.17
+[GoLang](https://golang.org/dl/)|1.18
 [golangci-lint](https://golangci-lint.run/usage/install/)|1.45.2
 
 ## Modifying the claim schema

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/test-network-function-claim
 
-go 1.17
+go 1.18
 
 require (
 	github.com/a-h/generate v0.0.0-20190312091541-e59c34d33fb3


### PR DESCRIPTION
Similar to:
https://github.com/test-network-function/cnf-certification-test/pull/129

The linter throws warnings due to [this issue](https://github.com/golangci/golangci-lint/issues/2649) but doesn't cause failures.
