### PR TITLE
Upgrade to v3 setup-go action

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.1
 

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.1
 


### PR DESCRIPTION
https://github.com/actions/setup-go/releases/tag/v3.0.0

v3 is the latest available release of `setup-go`.

Similar to: https://github.com/test-network-function/cnf-certification-test/pull/205