### PR TITLE
Upgrade to v3 checkout action

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: 1.18.1
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build and Run Tests
         run: make generate-golang-schema build tests

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.18.1
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Tests
         run: make generate-golang-schema build tests


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/204

https://github.com/actions/checkout/releases/tag/v3.0.2

`checkout` v3 is the latest available.