### PR TITLE
Update golangci-lint to v1.47.x

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,6 +130,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.45.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.47.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ At a minimum, the following dependencies must be installed to work with the GoLa
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.18
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.45.2
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.47.2
 
 ## Modifying the claim schema
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/test-network-function/test-network-function-claim
 go 1.18
 
 require (
-	github.com/a-h/generate v0.0.0-20190312091541-e59c34d33fb3
+	github.com/a-h/generate v0.0.0-20220105161013-96c14dfdfb60
 	github.com/stretchr/testify v1.8.0
+	golang.org/x/text v0.3.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/a-h/generate v0.0.0-20190312091541-e59c34d33fb3 h1:Ddgcglj3p+q6QqZ5n48lh7ZysGiKjUgdGOskKSik0xY=
-github.com/a-h/generate v0.0.0-20190312091541-e59c34d33fb3/go.mod h1:traiLYQ0YD7qUMCdjo6/jSaJRPHXniX4HVs+PhEhYpc=
+github.com/a-h/generate v0.0.0-20220105161013-96c14dfdfb60 h1:/rNdG6EuzjwcR1KRFpF+9qWmWh2xIcz84QOeMGr/2L8=
+github.com/a-h/generate v0.0.0-20220105161013-96c14dfdfb60/go.mod h1:traiLYQ0YD7qUMCdjo6/jSaJRPHXniX4HVs+PhEhYpc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -10,6 +10,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/generate/config.go
+++ b/internal/generate/config.go
@@ -15,8 +15,9 @@ package generate
 import (
 	"encoding/json"
 	"os"
-	"strings"
-	"unicode"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -53,13 +54,8 @@ func GetOverrideConfig(overrideConfigFile string) (*OverrideConfig, error) {
 
 	// Makes sure the first character is upper case, as this is how the generator handles properties.
 	for _, overrideProperty := range overrideConfig.Properties {
-		i := 0
 		for _, pathElement := range overrideProperty.Path {
-			runes := []rune(pathElement)
-			if unicode.IsLower(runes[0]) {
-				overrideProperty.Path[i] = strings.Title(pathElement)
-			}
-			i++
+			overrideProperty.Path = append(overrideProperty.Path, cases.Title(language.Und, cases.NoLower).String(pathElement))
 		}
 	}
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.47.0

Related to:
- https://github.com/test-network-function/cnf-certification-test/pull/358
- https://github.com/test-network-function/l2discovery/pull/10
- https://github.com/test-network-function/cnfcert-tests-verification/pull/113