### PR TITLE
Update Go to v1.19.2

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.2
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.2
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/xtuG5faxtaU

Security: Includes security fixes for archive/tar (CVE-2022-2879), net/http (CVE-2022-2880), and regexp (CVE-2022-41715).

Related to: https://github.com/test-network-function/cnf-certification-test/pull/571