### PR TITLE
Upgrade Golangci-lint to v1.50.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -128,6 +128,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.49.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.50.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ At a minimum, the following dependencies must be installed to work with the GoLa
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.19
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.49.0
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.50.0
 
 ## Modifying the claim schema
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.50.0

Related to: https://github.com/test-network-function/cnf-certification-test/pull/604