### PR TITLE
Update Go to v1.19.5

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.4
+          go-version: 1.19.5
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.4
+          go-version: 1.19.5
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/wrmRT7JlevE

Related to: https://github.com/test-network-function/cnf-certification-test/pull/779