### PR TITLE
Slight modification to the testID

### DIFF
--- a/pkg/claim/catalog.go
+++ b/pkg/claim/catalog.go
@@ -50,7 +50,7 @@ func formTestTags(tags ...string) string {
 func BuildTestCaseDescription(testID, suiteName, description, remediation, testType, exception, reference string, qe bool, tags ...string) (TestCaseDescription, Identifier) {
 	aID := Identifier{
 		Tags: formTestTags(tags...),
-		Id:   testID,
+		Id:   suiteName + "/" + testID,
 	}
 	aTCDescription := TestCaseDescription{}
 	aTCDescription.Identifier = aID


### PR DESCRIPTION
The previous func:

```
func formTestURL(suite, name string) string {
	return fmt.Sprintf("%s/%s/%s", url, suite, name)
}
```

Used to build the TestURL with a combination of the suite name and the test name with a "/" in the middle.  Returning some of that functionality.