### PR TITLE
Update GolangCI-lint to v1.53.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ At a minimum, the following dependencies must be installed to work with the GoLa
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.20
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.52.1
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.53.3
 
 ## Modifying the claim schema
 


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/1236

https://github.com/golangci/golangci-lint/releases/tag/v1.53.3