### PR TITLE
Update Go to v1.21.0

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.7
+          go-version: 1.21.0
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.7
+          go-version: 1.21.0
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ At a minimum, the following dependencies must be installed to work with the GoLa
 
 Dependency|Minimum Version
 ---|---
-[GoLang](https://golang.org/dl/)|1.20
+[GoLang](https://golang.org/dl/)|1.21
 [golangci-lint](https://golangci-lint.run/usage/install/)|1.53.3
 
 ## Modifying the claim schema

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/test-network-function-claim
 
-go 1.20
+go 1.21
 
 require (
 	github.com/a-h/generate v0.0.0-20220105161013-96c14dfdfb60


### PR DESCRIPTION
https://go.dev/doc/go1.21

Related to: https://github.com/test-network-function/cnf-certification-test/pull/1344