### PR TITLE
Fix go directive to include patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/test-network-function-claim
 
-go 1.21
+go 1.21.1
 
 require (
 	github.com/a-h/generate v0.0.0-20220105161013-96c14dfdfb60


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/1392